### PR TITLE
add overflow and remove center items

### DIFF
--- a/src/assets/sass/components/_dialog.scss
+++ b/src/assets/sass/components/_dialog.scss
@@ -16,7 +16,7 @@
 }
 
 .dialog-container {
-    align-items: center;
+    overflow: auto;
     display: flex;
     height: 100%;
     justify-content: center;


### PR DESCRIPTION
when the content of a dialog is greater than the view, there is no ability to scroll. Align items center centered the view in the center of the content instead of the top of the dialog. this seemed to resolve both without changing the layout of a dialog with content smaller than the view.